### PR TITLE
Limit athena player visibilty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [Unreleased]
+### Added
+- Athena hack to hide other players
+
+  Hides other units and vehicles except the player and player's vehicle from
+  Athena by default. Follows a missionNamespace variable "ath_all_data" to
+  determine whether all data should be displayed.
+
 ## [1.11.0] - 2020-08-13
 ### Added
 - Keybind for Earplugs volume control.

--- a/source/@zeusops/addons/zeusops_addon/XEH_preInit.sqf
+++ b/source/@zeusops/addons/zeusops_addon/XEH_preInit.sqf
@@ -1,1 +1,6 @@
 #include "initSettings.sqf"
+
+// Define functions here early before Athena has a chance to define them
+fnc_gatherGroups     = compileFinal preprocessFileLineNumbers "\zeusops_addon\athena\gatherGroups.sqf";
+fnc_gatherUnits      = compileFinal preprocessFileLineNumbers "\zeusops_addon\athena\gatherUnits.sqf";
+fnc_gatherVehicles   = compileFinal preprocessFileLineNumbers "\zeusops_addon\athena\gatherVehicles.sqf";

--- a/source/@zeusops/addons/zeusops_addon/athena/gatherGroups.sqf
+++ b/source/@zeusops/addons/zeusops_addon/athena/gatherGroups.sqf
@@ -1,0 +1,53 @@
+private ["_side", "_groups", "_groupsF"];
+private ["_id", "_leaderNetId", "_groupNetId", "_wpx", "_wpy"];
+
+//Params
+_side  = param[0,""];
+
+//Vars
+_groups   = [];
+_groupsF  = [];
+
+//Iterate through all known groups
+{ 
+	//Check to see if groups are on player side
+	if((side _x) == _side) then {
+		_id = groupid _x;
+		_leaderNetId = (leader _x) call BIS_fnc_netID;
+		_groupNetId = _x call BIS_fnc_netID;
+		_wpx = "";
+		_wpy = "";
+		
+		//Get coordinates of next waypoint
+		if((currentWaypoint _x) < (count waypoints _x)) then {
+			_wpx = getWPPos[_x, currentWaypoint _x] select 0;
+			_wpy = getWPPos[_x, currentWaypoint _x] select 1;
+		};
+		
+		_groups pushBack _x;		
+		_groupsF pushBack (format ['{"leaderNetID":"%1","groupNetId":"%2","name":"%3","id":"%4","side":"%5","wpx":"%6","wpy":"%7"}', _leaderNetId, _groupNetId, _x, _id, _side, _wpx, _wpy]);
+	};
+} forEach allGroups;
+
+if(isNil("_groups") || (count _groups) == 0) then {
+	_groups  = [];
+	_groupsF = [];	
+
+	_group = group player;	
+	_id = groupid _group;
+	_groupNetId = _group call BIS_fnc_netID;
+	_leaderNetId = (leader _group) call BIS_fnc_netID;
+	if (isNil("_leaderNetId") || _leaderNetId == "") then { _leaderNetId = player call BIS_fnc_netID; };
+
+	_wpx = "";
+	_wpy = "";
+	if((currentWaypoint _group) < (count waypoints _group)) then {
+		_wpx = getWPPos[_group, currentWaypoint _group] select 0;
+		_wpy = getWPPos[_group, currentWaypoint _group] select 1;
+	};
+
+	_groups pushBack (group player);	
+	_groupsF pushBack (format ['{"leaderNetID":"%1","groupNetId":"%2","name":"%3","id":"%4","side":"%5","wpx":"%6","wpy":"%7"}', _leaderNetId, _groupNetId, _group, _id, _side, _wpx, _wpy]);
+};
+
+[_groups, _groupsF];

--- a/source/@zeusops/addons/zeusops_addon/athena/gatherGroups.sqf
+++ b/source/@zeusops/addons/zeusops_addon/athena/gatherGroups.sqf
@@ -1,6 +1,8 @@
 private ["_side", "_groups", "_groupsF"];
 private ["_id", "_leaderNetId", "_groupNetId", "_wpx", "_wpy"];
 
+diag_log "[ZOPS] athena hack: gatherGroups init";
+
 //Params
 _side  = param[0,""];
 
@@ -8,8 +10,15 @@ _side  = param[0,""];
 _groups   = [];
 _groupsF  = [];
 
+_group_list = if (missionNamespace getVariable ["ath_all_data", false]) then {
+	allGroups;
+} else {
+	// Don't iterate any groups, will fall back to player's group
+	[];
+};
+
 //Iterate through all known groups
-{ 
+{
 	//Check to see if groups are on player side
 	if((side _x) == _side) then {
 		_id = groupid _x;
@@ -17,23 +26,23 @@ _groupsF  = [];
 		_groupNetId = _x call BIS_fnc_netID;
 		_wpx = "";
 		_wpy = "";
-		
+
 		//Get coordinates of next waypoint
 		if((currentWaypoint _x) < (count waypoints _x)) then {
 			_wpx = getWPPos[_x, currentWaypoint _x] select 0;
 			_wpy = getWPPos[_x, currentWaypoint _x] select 1;
 		};
-		
-		_groups pushBack _x;		
+
+		_groups pushBack _x;
 		_groupsF pushBack (format ['{"leaderNetID":"%1","groupNetId":"%2","name":"%3","id":"%4","side":"%5","wpx":"%6","wpy":"%7"}', _leaderNetId, _groupNetId, _x, _id, _side, _wpx, _wpy]);
 	};
-} forEach allGroups;
+} forEach _group_list;
 
 if(isNil("_groups") || (count _groups) == 0) then {
 	_groups  = [];
-	_groupsF = [];	
+	_groupsF = [];
 
-	_group = group player;	
+	_group = group player;
 	_id = groupid _group;
 	_groupNetId = _group call BIS_fnc_netID;
 	_leaderNetId = (leader _group) call BIS_fnc_netID;
@@ -46,7 +55,7 @@ if(isNil("_groups") || (count _groups) == 0) then {
 		_wpy = getWPPos[_group, currentWaypoint _group] select 1;
 	};
 
-	_groups pushBack (group player);	
+	_groups pushBack (group player);
 	_groupsF pushBack (format ['{"leaderNetID":"%1","groupNetId":"%2","name":"%3","id":"%4","side":"%5","wpx":"%6","wpy":"%7"}', _leaderNetId, _groupNetId, _group, _id, _side, _wpx, _wpy]);
 };
 

--- a/source/@zeusops/addons/zeusops_addon/athena/gatherUnits.sqf
+++ b/source/@zeusops/addons/zeusops_addon/athena/gatherUnits.sqf
@@ -1,6 +1,8 @@
 private ["_groups", "_units", "_unitsF", "_unitsP"];
 private ["_name", "_faction", "_side", "_type", "_rank", "_unitNetId", "_groupNetId", "_vehicleNetId", "_sessionid", "_steamid", "_player", "_hasmedikit", "_weapon1", "_weapon1isgl", "_weapon2"];
 
+diag_log "[ZOPS] athena hack: gatherUnits init";
+
 //Params
 _groups  = param[0,""];
 
@@ -9,12 +11,23 @@ _units   = [];
 _unitsF  = [];
 _unitsP  = playableUnits;
 
+_group_list = if (missionNamespace getVariable ["ath_all_data", false]) then {
+	_groups;
+} else {
+	if (!isNull objectParent player) then {
+		// If player is in a vehicle, gather data about passengers
+		crew (vehicle player);
+	} else {
+		[];
+	};
+};
+
 //Iterate through the known groups
-{ 
+{
 	//Iterate through the players in the current group
 	{
 		_name = name _x;
-		_faction = faction _x;	
+		_faction = faction _x;
 		_side = side _x;
 		_type = typeOf _x;
 		_rank = rank _x;
@@ -27,21 +40,21 @@ _unitsP  = playableUnits;
 		_hasmedikit = "0";
 		_weapon1 = (([primaryWeapon _x] call BIS_fnc_itemType) select 1);
 		_weapon1isgl = "0";
-		_weapon2 = (([secondaryWeapon _x] call BIS_fnc_itemType) select 1);	
+		_weapon2 = (([secondaryWeapon _x] call BIS_fnc_itemType) select 1);
 
 		//Check to see if the unit is in a vehicle
 		if(!(isNull objectParent _x)) then { _vehicleNetId = (vehicle _x) call BIS_fnc_netID; };
 
 		//Check to see if the unit has a medikit
 		if ("Medikit" in (backpackItems _x)) then { _hasmedikit = "1";};
-		
+
 		//Check to see if the primary weapon has multiple 'muzzles' indicating that it is a GL
 		if (count ((configFile >> "cfgWeapons" >> (primaryWeapon _x) >> "muzzles") call BIS_fnc_getCfgData) > 1) then { _weapon1isgl = "1";};
-		
+
 		//Collect different data depending on whether or not this is a 'playable unit'
 		if (count _unitsP == 0) then {
 			//No playable units, so must be singleplayer
-			
+
 			//Is this unit controlled by the player
 			if (isPlayer _x) then {
 				_player = profileName;
@@ -49,7 +62,7 @@ _unitsP  = playableUnits;
 			};
 		} else {
 			//There are playable units, must be multiplayer
-			
+
 			//Is this unit a playable unit
 			if (_x in _unitsP) then {
 				//Yes, is it player controlled
@@ -59,7 +72,7 @@ _unitsP  = playableUnits;
 						//Yes
 						_sessionid = owner _x;
 						_steamid = getPlayerUID _x;
-						_player = profileName;					
+						_player = profileName;
 					} else {
 						//No
 						_sessionid = owner _x;
@@ -70,39 +83,39 @@ _unitsP  = playableUnits;
 			};
 		};
 
-		_units pushBack _x;		
+		_units pushBack _x;
 		_unitsF pushBack (format ['{"name":"%1","netid":"%2","sessionid":"%3","steamid":"%4","player":"%5","faction":"%6","side":"%7","type":"%8","rank":"%9","groupnetid":"%10","vehiclenetid":"%11","weapon1":"%12","weapon1isgl":"%13","weapon2":"%14","hasmedikit":"%15"}',_name, _unitNetId, _sessionid, _steamid, _player, _faction, _side, _type, _rank, _groupNetId, _vehicleNetId, _weapon1, _weapon1isgl, _weapon2, _hasmedikit]);
 	} forEach units _x;
-} forEach _groups;
+} forEach _group_list;
 
 //Verify that we have unit data and if not, populate from player group
 if(isNil("_units") || (count _units) == 0) then {
 	_units  = [];
 	_unitsF = [];
-	
+
 	_unitNetId = player call BIS_fnc_netID;
 	_groupNetId = (group player) call BIS_fnc_netID;
 	_name = name player;
 	_sessionid = owner player;
 	_steamid = getPlayerUID player;
 	_player = name player;
-	_faction = faction player;	
+	_faction = faction player;
 	_side = side player;
 	_type = typeOf player;
 	_rank = rank player;
 	_weapon1 = (([primaryWeapon player] call BIS_fnc_itemType) select 1);
-	_weapon2 = (([secondaryWeapon player] call BIS_fnc_itemType) select 1);	
+	_weapon2 = (([secondaryWeapon player] call BIS_fnc_itemType) select 1);
 
 	_vehicleNetId = "";
 	if(!(isNull objectParent player)) then { _vehicleNetId = (vehicle player) call BIS_fnc_netID; };
 
 	_hasmedikit = "0";
 	if ("Medikit" in (backpackItems player)) then { _hasmedikit = "1"; };
-	
-	_weapon1isgl = "0";	
+
+	_weapon1isgl = "0";
 	if (count ((configFile >> "cfgWeapons" >> (primaryWeapon player) >> "muzzles") call BIS_fnc_getCfgData) > 1) then { _weapon1isgl = "1";};
 
-	_units pushBack player;		
+	_units pushBack player;
 	_unitsF pushBack (format ['{"name":"%1","netid":"%2","sessionid":"%3","steamid":"%4","player":"%5","faction":"%6","side":"%7","type":"%8","rank":"%9","groupnetid":"%10","vehiclenetid":"%11","weapon1":"%12","weapon1isgl":"%13","weapon2":"%14","hasmedikit":"%15"}',_name, _unitNetId, _sessionid, _steamid, _player, _faction, _side, _type, _rank, _groupNetId, _vehicleNetId, _weapon1, _weapon1isgl, _weapon2, _hasmedikit]);
 };
 

--- a/source/@zeusops/addons/zeusops_addon/athena/gatherUnits.sqf
+++ b/source/@zeusops/addons/zeusops_addon/athena/gatherUnits.sqf
@@ -1,0 +1,110 @@
+private ["_groups", "_units", "_unitsF", "_unitsP"];
+private ["_name", "_faction", "_side", "_type", "_rank", "_unitNetId", "_groupNetId", "_vehicleNetId", "_sessionid", "_steamid", "_player", "_hasmedikit", "_weapon1", "_weapon1isgl", "_weapon2"];
+
+//Params
+_groups  = param[0,""];
+
+//Vars
+_units   = [];
+_unitsF  = [];
+_unitsP  = playableUnits;
+
+//Iterate through the known groups
+{ 
+	//Iterate through the players in the current group
+	{
+		_name = name _x;
+		_faction = faction _x;	
+		_side = side _x;
+		_type = typeOf _x;
+		_rank = rank _x;
+		_unitNetId = _x call BIS_fnc_netID;
+		_groupNetId = (group _x) call BIS_fnc_netID;
+		_vehicleNetId = "";
+		_sessionid = '';
+		_steamid = '';
+		_player = '';
+		_hasmedikit = "0";
+		_weapon1 = (([primaryWeapon _x] call BIS_fnc_itemType) select 1);
+		_weapon1isgl = "0";
+		_weapon2 = (([secondaryWeapon _x] call BIS_fnc_itemType) select 1);	
+
+		//Check to see if the unit is in a vehicle
+		if(!(isNull objectParent _x)) then { _vehicleNetId = (vehicle _x) call BIS_fnc_netID; };
+
+		//Check to see if the unit has a medikit
+		if ("Medikit" in (backpackItems _x)) then { _hasmedikit = "1";};
+		
+		//Check to see if the primary weapon has multiple 'muzzles' indicating that it is a GL
+		if (count ((configFile >> "cfgWeapons" >> (primaryWeapon _x) >> "muzzles") call BIS_fnc_getCfgData) > 1) then { _weapon1isgl = "1";};
+		
+		//Collect different data depending on whether or not this is a 'playable unit'
+		if (count _unitsP == 0) then {
+			//No playable units, so must be singleplayer
+			
+			//Is this unit controlled by the player
+			if (isPlayer _x) then {
+				_player = profileName;
+				_steamid = getPlayerUID player;
+			};
+		} else {
+			//There are playable units, must be multiplayer
+			
+			//Is this unit a playable unit
+			if (_x in _unitsP) then {
+				//Yes, is it player controlled
+				if (isPlayer _x) then {
+					//Yes, is it 'our' player?
+					if(_x == player) then{
+						//Yes
+						_sessionid = owner _x;
+						_steamid = getPlayerUID _x;
+						_player = profileName;					
+					} else {
+						//No
+						_sessionid = owner _x;
+						_steamid = getPlayerUID _x;
+						_player = name _x;
+					};
+				};
+			};
+		};
+
+		_units pushBack _x;		
+		_unitsF pushBack (format ['{"name":"%1","netid":"%2","sessionid":"%3","steamid":"%4","player":"%5","faction":"%6","side":"%7","type":"%8","rank":"%9","groupnetid":"%10","vehiclenetid":"%11","weapon1":"%12","weapon1isgl":"%13","weapon2":"%14","hasmedikit":"%15"}',_name, _unitNetId, _sessionid, _steamid, _player, _faction, _side, _type, _rank, _groupNetId, _vehicleNetId, _weapon1, _weapon1isgl, _weapon2, _hasmedikit]);
+	} forEach units _x;
+} forEach _groups;
+
+//Verify that we have unit data and if not, populate from player group
+if(isNil("_units") || (count _units) == 0) then {
+	_units  = [];
+	_unitsF = [];
+	
+	_unitNetId = player call BIS_fnc_netID;
+	_groupNetId = (group player) call BIS_fnc_netID;
+	_name = name player;
+	_sessionid = owner player;
+	_steamid = getPlayerUID player;
+	_player = name player;
+	_faction = faction player;	
+	_side = side player;
+	_type = typeOf player;
+	_rank = rank player;
+	_weapon1 = (([primaryWeapon player] call BIS_fnc_itemType) select 1);
+	_weapon2 = (([secondaryWeapon player] call BIS_fnc_itemType) select 1);	
+
+	_vehicleNetId = "";
+	if(!(isNull objectParent player)) then { _vehicleNetId = (vehicle player) call BIS_fnc_netID; };
+
+	_hasmedikit = "0";
+	if ("Medikit" in (backpackItems player)) then { _hasmedikit = "1"; };
+	
+	_weapon1isgl = "0";	
+	if (count ((configFile >> "cfgWeapons" >> (primaryWeapon player) >> "muzzles") call BIS_fnc_getCfgData) > 1) then { _weapon1isgl = "1";};
+
+	_units pushBack player;		
+	_unitsF pushBack (format ['{"name":"%1","netid":"%2","sessionid":"%3","steamid":"%4","player":"%5","faction":"%6","side":"%7","type":"%8","rank":"%9","groupnetid":"%10","vehiclenetid":"%11","weapon1":"%12","weapon1isgl":"%13","weapon2":"%14","hasmedikit":"%15"}',_name, _unitNetId, _sessionid, _steamid, _player, _faction, _side, _type, _rank, _groupNetId, _vehicleNetId, _weapon1, _weapon1isgl, _weapon2, _hasmedikit]);
+};
+
+[_units, _unitsF];
+

--- a/source/@zeusops/addons/zeusops_addon/athena/gatherVehicles.sqf
+++ b/source/@zeusops/addons/zeusops_addon/athena/gatherVehicles.sqf
@@ -1,6 +1,8 @@
 private ["_side", "_vehs", "_vehsF"];
 private ["_crew", "_type", "_netid", "_class", "_crewStrings", "_crewNetID", "_crewPosition"];
 
+diag_log "[ZOPS] athena hack: gatherVehicles init";
+
 //Params
 _side  = param[0,""];
 
@@ -8,27 +10,38 @@ _side  = param[0,""];
 _vehs   = [];
 _vehsF  = [];
 
+_vehicle_list = if (missionNamespace getVariable ["ath_all_data", false]) then {
+	vehicles;
+} else {
+	if (!isNull objectParent player) then {
+		// If player is in a vehicle, gather data about the vehicle
+		[vehicle player];
+	} else {
+		[];
+	};
+};
+
 //Iterate through all vehicles
-{ 
+{
 	//Check if current vehicle is crewed by units of the specified side
 	if((side _x) == _side) then {
 		//Get a list of the crew members
 		_crew = fullCrew _x;
-		
+
 		//Make sure there are at least 1
 		if(count _crew > 0) then {
 			_type = typeOf _x;
 			_netid = _x call BIS_fnc_netID;
-			
+
 			_class = 1; //car, default
-			if (_x isKindOf "tank") then {_class=3;}; //tank 
+			if (_x isKindOf "tank") then {_class=3;}; //tank
 			if (_x isKindOf "tank" && ((configFile >> "cfgVehicles" >> (typeOf _x) >> "transportSoldier") call BIS_fnc_getCfgData) > 6) then {_class=2;}; //apc (an apc may be a tank ... but carries soldiers)
 			if (_x isKindOf "helicopter") then {_class=4;}; //chopper
 			if (_x isKindOf "plane") then {_class=5;}; //plane
 			if (_x isKindOf "uav") then {_class=6;}; //uav (most uavs are planes but not all planes are uavs ... they're probably choppers too now that I think of it)
 			if (_x isKindOf "ship") then {_class=7;}; //ship
 			if (_x isKindOf "sub") then {_class=8;}; //sub (all subs are ships but not all ships are subs)
-			
+
 			//Compose a delimited string of the crew member details
 			_crewStrings = [];
 			{
@@ -36,11 +49,11 @@ _vehsF  = [];
 				_crewPosition = _x select 1;
 				_crewStrings pushBack (_crewNetID + ";" + _crewPosition);
 			} forEach _crew;
-			
+
 			_vehs pushBack _x;
 			_vehsF pushBack (format ['{"netid":"%1","name":"%2","type":"%3","class":"%4","crew":"%5"}', _netid, _x, _type, _class, _crewStrings joinString ","]);
 		}
 	};
-} forEach vehicles;
+} forEach _vehicle_list;
 
 [_vehs, _vehsF];

--- a/source/@zeusops/addons/zeusops_addon/athena/gatherVehicles.sqf
+++ b/source/@zeusops/addons/zeusops_addon/athena/gatherVehicles.sqf
@@ -1,0 +1,46 @@
+private ["_side", "_vehs", "_vehsF"];
+private ["_crew", "_type", "_netid", "_class", "_crewStrings", "_crewNetID", "_crewPosition"];
+
+//Params
+_side  = param[0,""];
+
+//Vars
+_vehs   = [];
+_vehsF  = [];
+
+//Iterate through all vehicles
+{ 
+	//Check if current vehicle is crewed by units of the specified side
+	if((side _x) == _side) then {
+		//Get a list of the crew members
+		_crew = fullCrew _x;
+		
+		//Make sure there are at least 1
+		if(count _crew > 0) then {
+			_type = typeOf _x;
+			_netid = _x call BIS_fnc_netID;
+			
+			_class = 1; //car, default
+			if (_x isKindOf "tank") then {_class=3;}; //tank 
+			if (_x isKindOf "tank" && ((configFile >> "cfgVehicles" >> (typeOf _x) >> "transportSoldier") call BIS_fnc_getCfgData) > 6) then {_class=2;}; //apc (an apc may be a tank ... but carries soldiers)
+			if (_x isKindOf "helicopter") then {_class=4;}; //chopper
+			if (_x isKindOf "plane") then {_class=5;}; //plane
+			if (_x isKindOf "uav") then {_class=6;}; //uav (most uavs are planes but not all planes are uavs ... they're probably choppers too now that I think of it)
+			if (_x isKindOf "ship") then {_class=7;}; //ship
+			if (_x isKindOf "sub") then {_class=8;}; //sub (all subs are ships but not all ships are subs)
+			
+			//Compose a delimited string of the crew member details
+			_crewStrings = [];
+			{
+				_crewNetID = (_x select 0) call BIS_fnc_netID;
+				_crewPosition = _x select 1;
+				_crewStrings pushBack (_crewNetID + ";" + _crewPosition);
+			} forEach _crew;
+			
+			_vehs pushBack _x;
+			_vehsF pushBack (format ['{"netid":"%1","name":"%2","type":"%3","class":"%4","crew":"%5"}', _netid, _x, _type, _class, _crewStrings joinString ","]);
+		}
+	};
+} forEach vehicles;
+
+[_vehs, _vehsF];


### PR DESCRIPTION
Hides other units and vehicles except the player and player's vehicle from
Athena by default. Follows a missionNamespace variable "ath_all_data" to
determine whether all data should be displayed.